### PR TITLE
Skip open window checks if unsupported or disabled within the zone

### DIFF
--- a/tado-assistant.sh
+++ b/tado-assistant.sh
@@ -116,6 +116,17 @@ homeState() {
     echo "$zones" | jq -c '.[]' | while read -r zone; do
         zone_id=$(echo "$zone" | jq -r '.id')
         zone_name=$(echo "$zone" | jq -r '.name')
+
+        open_window_detection_supported=$(echo "$zone" | jq -r '.openWindowDetection.supported')
+        if [ "$open_window_detection_supported" = false ]; then
+            continue
+        fi
+
+        open_window_detection_enabled=$(echo "$zone" | jq -r '.openWindowDetection.enabled')
+        if [ "$open_window_detection_enabled" = false ]; then
+            continue
+        fi
+
         open_window_detected=$(curl -s -X GET "https://my.tado.com/api/v2/homes/$HOME_ID/zones/$zone_id/state" -H "Authorization: Bearer $TOKEN" | jq -r '.openWindowDetected')
         handle_curl_error
 


### PR DESCRIPTION
In the response from `https://my.tado.com/api/v2/homes/<id>/zones`, some zones won't support the open window feature, and some may have it disabled by the user. For example, a zone of type `HOT_WATER` has
```json
"openWindowDetection": {
  "supported": false
}
```
This change adds a check to see if it is unsupported and skips to save time. If it is supported, check to see if the user has not disabled the feature
```json
"openWindowDetection": {
  "supported": true,
  "enabled": false,
  "timeoutInSeconds": 1800
}
```
This will save a little bit of time and avoid turning off the heating if the user has disabled the feature.