### PR TITLE
Url encodes Tado username and password and adds raspbian support

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -30,7 +30,7 @@ install_dependencies() {
         fi
 
         case $DISTRO in
-            debian|ubuntu)
+            debian|ubuntu|raspbian)
                 if [[ $NEED_CURL -eq 1 ]] || [[ $NEED_JQ -eq 1 ]]; then
                     sudo apt-get update
                 fi

--- a/install.sh
+++ b/install.sh
@@ -175,9 +175,9 @@ validate_credentials() {
         -d "client_id=public-api-preview" \
         -d "client_secret=4HJGRffVR8xb3XdEUQpjgZ1VplJi6Xgw" \
         -d "grant_type=password" \
-        -d "password=${password}" \
+        --data-urlencode "password=${password}" \
         -d "scope=home.user" \
-        -d "username=${username}"); then
+        --data-urlencode "username=${username}"); then
         echo "Error connecting to the API."
         return 1
     fi

--- a/tado-assistant.sh
+++ b/tado-assistant.sh
@@ -56,7 +56,8 @@ login() {
     local response expires_in token home_data home_id
 
     response=$(curl -s -X POST "https://auth.tado.com/oauth/token" \
-        -d "client_id=public-api-preview&client_secret=4HJGRffVR8xb3XdEUQpjgZ1VplJi6Xgw&grant_type=password&password=$password&scope=home.user&username=$username")
+        -d "client_id=public-api-preview&client_secret=4HJGRffVR8xb3XdEUQpjgZ1VplJi6Xgw&grant_type=password&scope=home.user" \
+        --data-urlencode "username=$username" --data-urlencode "password=$password")
     handle_curl_error
 
     token=$(echo "$response" | jq -r '.access_token')


### PR DESCRIPTION
Tado `username` and `password` might need to be URL encoded when used with curl, this PR adds support for this.
Additionally extends debian and ubuntu with raspbian OS.

Tested on Raspberry Pi running:
```
PRETTY_NAME="Raspbian GNU/Linux 10 (buster)"
NAME="Raspbian GNU/Linux"
VERSION_ID="10"
VERSION="10 (buster)"
VERSION_CODENAME=buster
ID=raspbian
ID_LIKE=debian
HOME_URL="http://www.raspbian.org/"
SUPPORT_URL="http://www.raspbian.org/RaspbianForums"
BUG_REPORT_URL="http://www.raspbian.org/RaspbianBugs"
```

This might fix https://github.com/BrainicHQ/tado-assistant/issues/6