### PR TITLE
Added Oracle Linux support to allow deployment to Oracle Cloud Free Tier

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -37,7 +37,7 @@ install_dependencies() {
                 [[ $NEED_CURL -eq 1 ]] && sudo apt-get install -y curl
                 [[ $NEED_JQ -eq 1 ]] && sudo apt-get install -y jq
                 ;;
-            fedora|centos|rhel)
+            fedora|centos|rhel|ol)
                 [[ $NEED_CURL ]] && sudo yum install -y curl
                 [[ $NEED_JQ ]] && sudo yum install -y jq
                 ;;


### PR DESCRIPTION
Simple change to add Oracle Linux to the list of distros to allow deployment to the Oracle Cloud Free Tier