### PR TITLE
Fix log file permissions when running via Docker

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -431,7 +431,7 @@ EOF
         systemctl enable --now "tado-api-proxy@${account_index}.service" 1>&2
     elif [[ "$OSTYPE" == "darwin"* ]] && command -v launchctl &> /dev/null; then
         setup_launchd_proxy_service "$account_index"
-    else
+    elif ! in_container; then
         local log_file="/var/log/tado-api-proxy-account${account_index}.log"
         mkdir -p "$(dirname "$log_file")"
         (
@@ -671,7 +671,14 @@ if [[ "$1" == "--update" ]] || [[ "$1" == "--force-update" ]]; then
     exit 0
 fi
 
-install_dependencies
-set_env_variables
-setup_service
+if ! in_container; then
+    # Native installation: full setup
+    install_dependencies
+    set_env_variables
+    setup_service
+else
+    # Container setup: only config, no installation or services
+    set_env_variables
+fi
+
 echo "Tado Assistant has been successfully installed and started!"


### PR DESCRIPTION
## Problem

When following the instructions to run the project via Docker, the following issue is encountered:

```
29-12-2025 10:05:13 # Curl command failed. Retrying in 60 seconds.
29-12-2025 10:06:13 # ⚠️ Error fetching home ID for account 1!
29-12-2025 10:06:14 # 🔌 Account 1: Using tado-api-proxy at http://localhost:8080/
29-12-2025 10:06:14 # 🔌 Account 1: Starting local tado-api-proxy.
/usr/local/bin/tado-assistant.sh: line 144: /var/log/tado-api-proxy-account1.log: Permission denied
29-12-2025 10:06:15 # Curl command failed. Retrying in 60 seconds.
```

## Why this happens

This happens because `install.sh` runs as root inside the container, creating log files owned as `root:root`. `tado-assistant.sh` later runs as `appuser` which then cannot write to these files.

## Solution

The fix is to make `install.sh` container-aware so it skips starting the proxy, allowing `tado-assistant.sh` (running as `appuser`) to start it instead, creating log files with correct ownership from the start. In the container, some of the binary setup is already provided, so we can safely skip those steps.

### Temporary workaround

Until this is merged, as a temporary workaround you can do: `sudo chown 1000:1000 ./tado-data/logs/tado-api-proxy-account1.log` after running the container setup once.

